### PR TITLE
Use @Lob for cross-DBMS compatibility for large object columns

### DIFF
--- a/src/main/java/org/nsesa/server/domain/AmendmentContainer.java
+++ b/src/main/java/org/nsesa/server/domain/AmendmentContainer.java
@@ -79,7 +79,7 @@ public class AmendmentContainer {
     /**
      * The serialized body/payload of this amendment. Can be XML or JSON, depending on what your backend provides.
      */
-    @Column(columnDefinition = "TEXT")
+    @Lob
     private String body;
 
     /**

--- a/src/main/java/org/nsesa/server/domain/DocumentContent.java
+++ b/src/main/java/org/nsesa/server/domain/DocumentContent.java
@@ -25,7 +25,7 @@ public class DocumentContent {
     /**
      * XML content.
      */
-    @Column(columnDefinition = "TEXT")
+    @Lob
     private String content;
 
     @Enumerated(value = EnumType.STRING)


### PR DESCRIPTION
Replaces the hard-coded column type `TEXT`, which wasn't large enough in MySQL. `@Lob` instead uses `LONGTEXT`, which works.

Tested with the H2 in-memory database and MySQL 5.6.
