### PR TITLE
Allow custom nsesa-server.properties path

### DIFF
--- a/src/main/resources/nsesa-server.properties
+++ b/src/main/resources/nsesa-server.properties
@@ -1,3 +1,7 @@
+# Default properties file (supposed to be overridden by an external file called nsesa-server.properties)
+# in the /${user.home} directory or by setting the java parameter/environment variable
+# NSESA_SERVER_PROPERTIES to a path such as /any/path/nsesa-server.properties.
+
 # Database Configuration
 
 jdbc.driver=org.h2.Driver

--- a/web/WEB-INF/applicationContext.xml
+++ b/web/WEB-INF/applicationContext.xml
@@ -18,13 +18,16 @@
              http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd">
 
     <!-- Configure the properties via placeholders. We will first read the properties file on the classpath,
-        which can be overridden via another properties file in the local home directory. -->
+    which can be overridden via another properties file in the local home directory and finally by setting
+    the java parameter/environment variable NSESA_SERVER_PROPERTIES to a path
+    such as /any/path/nsesa-server.properties. -->
     <bean id="propertyConfigurer"
           class="org.springframework.context.support.PropertySourcesPlaceholderConfigurer">
         <property name="locations">
             <list>
                 <value>classpath:nsesa-server.properties</value>
                 <value>file:///${user.home}/nsesa-server.properties</value>
+                <value>file://#{ systemProperties['NSESA_SERVER_PROPERTIES'] }</value>
             </list>
         </property>
         <property name="ignoreUnresolvablePlaceholders" value="false"/>


### PR DESCRIPTION
By setting the environment variable `NSESA_SERVER_PROPERTIES` or java
parameter `-DNSESA_SERVER_PROPERTIES` to a path such as
`/any/path/nsesa-server.properties` properties can be loaded from
anywhere in the file system. This is useful for production systems.

Loading from `${user.home}/nsesa-server.properties` is still supported.

---

Edit: hard-coded `file://` which means less typing, less flexibility and no null pointer exceptions when no value was set.
